### PR TITLE
fixed stray text

### DIFF
--- a/mediaQuery2.css
+++ b/mediaQuery2.css
@@ -1,6 +1,6 @@
 #container{
     height:500px;
-    width:960px;
+    width: 100%;
     margin: 0px auto;
     background: green;
 }
@@ -9,9 +9,10 @@
     float: left;
 }
 #para{
-    width: 560px;
-    float: left;
     background: orange;
+}
+p{
+    margin-left:400px;
 }
 
 @media screen and (max-width:959px){
@@ -22,7 +23,7 @@
         width:40%;
     }
     #para{
-        width:60%;
+        width: 100%;
     }
 }
 
@@ -32,8 +33,10 @@
         display: block;
     }
     #para{
-        width:100%;
-        display: block;
+        float: left;
+    }
+    p{
+        margin-left:0;
     }
 
 }


### PR DESCRIPTION
fixed the stray text on mediaQuery2 page by accounting for the image width with a margin and then overuling that margin when it drops down below the image